### PR TITLE
change clear historyStack to removeSubrange

### DIFF
--- a/Sources/SwiftUIRouter/Router.swift
+++ b/Sources/SwiftUIRouter/Router.swift
@@ -84,6 +84,6 @@ public final class HistoryData: ObservableObject {
     
     public func clear() {
         forwardStack.removeAll()
-        historyStack.removeAll()
+        historyStack.removeSubrange(1...)
     }
 }


### PR DESCRIPTION
I changed `HistoryData` clear function.

I think Cleaning `historyStack` requires retaining the root routing and returning to the initialization, otherwise `canGoBack` will need two routing jumps to return true, this is a bug.