### PR TITLE
Upped minimal supported watchOS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
 		.macOS(.v11),
 		.iOS(.v14),
 		.tvOS(.v14),
-		.watchOS(.v6)
+		.watchOS(.v7)
 	],
 	products: [
 		.library(


### PR DESCRIPTION
It's required to make the package available for watch apps due to using the `@StateObject` decorators

Otherwise, Swift compiler throws availability errors