### PR TITLE
Fix/invalid regex patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Route(path: "user/:id?") { info in
 A view that will only render its contents if its path matches that of the environment. Use `/*` to also match deeper paths. E.g.: the path `news/*` will match the following environment paths: `/news`, `/news/latest`, `/news/article/1` etc.
 
 #### Parameters
-Paths can contain parameters (aka variables) that can be read individually. A parameter's name is prefixed with a colon (`:`). Additionally, a parameter can be considered optional by suffixing it with a question mark (`?`). The parameters are passed down as a `[String : String]` in an `RouteInformation` object to a `Route`'s contents.
+Paths can contain parameters (aka placeholders) that can be read individually. A parameter's name is prefixed with a colon (`:`). Additionally, a parameter can be considered optional by suffixing it with a question mark (`?`). The parameters are passed down as a `[String : String]` in an `RouteInformation` object to a `Route`'s contents.  
+**Note**: Parameters may only exist of alphanumeric characters (A-Z, a-z and 0-9) and *must* start with a letter.
 
 #### Parameter validation
 ```swift

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -203,8 +203,8 @@ final class PathMatcher: ObservableObject {
 				#if DEBUG
 				// In debug mode perform an extra check whether parameters contain invalid characters or
 				// whether the parameters starts with something besides a letter.
-				if let range = variable.range(of: "(^[^A-Za-z]|[^A-Za-z0-9])", options: .regularExpression) {
-					throw CompileError.badParameter(variable, culprit: String(variable[range]))
+				if let r = variable.range(of: "(^[^a-z]|[^a-z0-9])", options: [.regularExpression, .caseInsensitive]) {
+					throw CompileError.badParameter(variable, culprit: String(variable[r]))
 				}
 				#endif
 				

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -108,9 +108,7 @@ public struct Route<ValidatedData, Content: View>: View {
 				}
 			}
 			catch {
-				print("Unable to compile path glob '\(path)' to Regex.")
-				print(error.localizedDescription)
-				fatalError()
+				fatalError("Unable to compile path glob '\(path)' to Regex. Error: \(error)")
 			}
 		}
 
@@ -176,7 +174,7 @@ final class PathMatcher: ObservableObject {
 		let parameters: Set<String>
 	}
 	
-	fileprivate enum CompileError: Error {
+	public enum CompileError: Error {
 		case badParameter(String, culprit: String)
 	}
 	

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -174,7 +174,7 @@ final class PathMatcher: ObservableObject {
 		let parameters: Set<String>
 	}
 	
-	public enum CompileError: Error {
+	private enum CompileError: Error {
 		case badParameter(String, culprit: String)
 	}
 	

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -108,7 +108,7 @@ public struct Route<ValidatedData, Content: View>: View {
 				}
 			}
 			catch {
-				print("Unable to compile path glob to Regex.")
+				print("Unable to compile path glob '\(path)' to Regex.")
 				#if DEBUG
 				fatalError(error.localizedDescription)
 				#endif

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -109,7 +109,8 @@ public struct Route<ValidatedData, Content: View>: View {
 			}
 			catch {
 				print("Unable to compile path glob '\(path)' to Regex.")
-				fatalError(error.localizedDescription)
+				print(error.localizedDescription)
+				fatalError()
 			}
 		}
 
@@ -169,17 +170,19 @@ public final class RouteInformation: ObservableObject {
 /// any parsed information (like identifiers).
 final class PathMatcher: ObservableObject {
 
-	private static let variablesRegex = try! NSRegularExpression(pattern: #":([^\/\?]+)"#, options: [])
-
 	private struct CompiledRegex {
 		let path: String
 		let matchRegex: NSRegularExpression
 		let parameters: Set<String>
 	}
 	
-	enum CompileError: Error {
+	fileprivate enum CompileError: Error {
 		case badParameter(String, culprit: String)
 	}
+	
+	private static let variablesRegex = try! NSRegularExpression(pattern: #":([^\/\?]+)"#, options: [])
+
+	//
 
 	private var cached: CompiledRegex?
 	

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -149,12 +149,27 @@ final class SwiftUIRouterTests: XCTestCase {
 			"/:id1/:id2",
 			"/:id1/:id2?",
 			"/:id/*",
+			"/:i", // Single character.
 		]
 		
 		for glob in goodGlobs {
 			XCTAssertNoThrow(
 				try pathMatcher.match(glob: glob, with: ""),
 				"Glob \(glob) causes bad Regex." 
+			)
+		}
+		
+		// These bad globs should throw at Regex compilation.
+		let badGlobs: [String] = [
+			"/:0", // Starting with numerics.
+			"/:user-id", // Illegal characters.
+			"/:foo_bar",
+		]
+		
+		for glob in badGlobs {
+			XCTAssertThrowsError(
+				try pathMatcher.match(glob: glob, with: ""),
+				"Glob \(glob) should've thrown an error, but didn't."
 			)
 		}
 	}

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -148,7 +148,7 @@ final class SwiftUIRouterTests: XCTestCase {
 			"/:id?",
 			"/:id1/:id2",
 			"/:id1/:id2?",
-			"/:id/*",
+			"/:Movie/*",
 			"/:i", // Single character.
 		]
 		
@@ -164,6 +164,7 @@ final class SwiftUIRouterTests: XCTestCase {
 			"/:0abc", // Starting with numerics.
 			"/:user-id", // Illegal characters.
 			"/:foo_bar",
+			"/:😀"
 		]
 		
 		for glob in badGlobs {

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -161,7 +161,7 @@ final class SwiftUIRouterTests: XCTestCase {
 		
 		// These bad globs should throw at Regex compilation.
 		let badGlobs: [String] = [
-			"/:0", // Starting with numerics.
+			"/:0abc", // Starting with numerics.
 			"/:user-id", // Illegal characters.
 			"/:foo_bar",
 		]


### PR DESCRIPTION
fixes #21 
* Added checks (and fatalError) for invalid parameter names.
* Added tests for said checks.
* Updated README and code documentation to mention the valid characterset of path parameter names.