### PR TITLE
fix: make replace in Navigate customizable

### DIFF
--- a/Sources/Navigate.swift
+++ b/Sources/Navigate.swift
@@ -28,10 +28,13 @@ public struct Navigate: View {
 	@Environment(\.relativePath) private var relativePath
 
 	private let path: String
-	
+
+	private let replace: Bool
+
 	/// - Parameter path: New path to navigate to once the View is rendered.
-	public init(to path: String) {
+	public init(to path: String, replace: Bool = true) {
 		self.path = path
+		self.replace = replace
 	}
 
 	public var body: some View {
@@ -39,7 +42,7 @@ public struct Navigate: View {
 			.hidden()
 			.onAppear {
 				if navigator.path != path {
-					navigator.navigate(resolvePaths(relativePath, path), replace: true)
+					navigator.navigate(resolvePaths(relativePath, path), replace: replace)
 				}
 			}
 	}


### PR DESCRIPTION
We use programmatic Navigation only and have some use cases where the history stack should not be replaced. I am not sure if true or false is the better option as a default value but to be backwards compatible I simply added it as an optional init param.

Please merge and release.