### PR TITLE
Fix/issue 40

### DIFF
--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -262,12 +262,14 @@ final class PathMatcher: ObservableObject {
 			.replacingOccurrences(of: "^[^/]/$", with: "", options: .regularExpression) // Trailing slash.
 			.replacingOccurrences(of: #"\/?\*"#, with: "", options: .regularExpression) // Trailing asterisk.
 		
-		for variable in variables {
+		for (index, variable) in variables.enumerated() {
+			let isAtRoot = index == 0 && glob.starts(with: "/:")
 			pattern = pattern.replacingOccurrences(
-				of: "/:" + variable,
-				with: "/(?<" + variable + ">[^/?]+)", // Named capture group.
+				of: (isAtRoot ? ":" : "/:") + variable,
+				with: "(?<\(variable)>" + (isAtRoot ? "" : "/") + "[^/?]+)", // Named capture group.
 				options: .regularExpression)
 		}
+
 		pattern = "^" +
 			(pattern.isEmpty ? "" : "(\(pattern))") +
 			(endsWithAsterisk ? "(/.*)?$" : "$")

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -63,14 +63,14 @@ import SwiftUI
 ///
 /// - Note: A `Route`'s default path is `*`, meaning it will always match.
 public struct Route<ValidatedData, Content: View>: View {
-	
+
 	public typealias Validator = (RouteInformation) -> ValidatedData?
 
 	@Environment(\.relativePath) private var relativePath
 	@EnvironmentObject private var navigator: Navigator
 	@EnvironmentObject private var switchEnvironment: SwitchRoutesEnvironment
 	@StateObject private var pathMatcher = PathMatcher()
-	
+
 	private let content: (ValidatedData) -> Content
 	private let path: String
 	private let validator: Validator
@@ -111,7 +111,7 @@ public struct Route<ValidatedData, Content: View>: View {
 				{
 					validatedData = validated
 					routeInformation = matchInformation
-					
+
 					if switchEnvironment.isActive {
 						switchEnvironment.isResolved = true
 					}
@@ -143,7 +143,7 @@ public extension Route where ValidatedData == RouteInformation {
 		self.validator = { $0 }
 		self.content = content
 	}
-	
+
 	/// - Parameter path: A path glob to test with the current path. See documentation for `Route`.
 	/// - Parameter content: Views to render.
 	init(_ path: String = "*", @ViewBuilder content: @escaping () -> Content) {
@@ -151,7 +151,7 @@ public extension Route where ValidatedData == RouteInformation {
 		self.validator = { $0 }
 		self.content = { _ in content() }
 	}
-	
+
 	/// - Parameter path: A path glob to test with the current path. See documentation for `Route`.
 	/// - Parameter content: View to render (autoclosure).
 	init(_ path: String = "*", content: @autoclosure @escaping () -> Content) {
@@ -190,13 +190,13 @@ public extension Route where ValidatedData == RouteInformation {
 public final class RouteInformation: ObservableObject {
 	/// The resolved path component of the parent `Route`. For internal use only, at the moment.
 	let matchedPath: String
-	
+
 	/// The current relative path.
 	public let path: String
 
 	/// Resolved parameters of the parent `Route`s path.
 	public let parameters: [String : String]
-	
+
 	init(path: String, matchedPath: String, parameters: [String : String] = [:]) {
 		self.matchedPath = matchedPath
 		self.parameters = parameters
@@ -215,11 +215,11 @@ final class PathMatcher: ObservableObject {
 		let matchRegex: NSRegularExpression
 		let parameters: Set<String>
 	}
-	
+
 	private enum CompileError: Error {
 		case badParameter(String, culprit: String)
 	}
-	
+
 	private static let variablesRegex = try! NSRegularExpression(pattern: #":([^\/\?]+)"#, options: [])
 
 	//
@@ -261,12 +261,12 @@ final class PathMatcher: ObservableObject {
 		var pattern = glob
 			.replacingOccurrences(of: "^[^/]/$", with: "", options: .regularExpression) // Trailing slash.
 			.replacingOccurrences(of: #"\/?\*"#, with: "", options: .regularExpression) // Trailing asterisk.
-		
+
 		for (index, variable) in variables.enumerated() {
-			let isAtRoot = index == 0 && glob.starts(with: "/:")
+			let isAtRoot = index == 0 && glob.starts(with: "/:" + variable)
 			pattern = pattern.replacingOccurrences(
-				of: (isAtRoot ? ":" : "/:") + variable,
-				with: "(?<\(variable)>" + (isAtRoot ? "" : "/") + "[^/?]+)", // Named capture group.
+				of: "/:" + variable,
+				with: (isAtRoot ? "/" : "") + "(?<\(variable)>" + (isAtRoot ? "" : "/?") + "[^/?]+)",
 				options: .regularExpression)
 		}
 
@@ -275,7 +275,7 @@ final class PathMatcher: ObservableObject {
 			(endsWithAsterisk ? "(/.*)?$" : "$")
 
 		let regex = try NSRegularExpression(pattern: pattern, options: [])
-		
+
 		cached = CompiledRegex(path: glob, matchRegex: regex, parameters: variables)
 
 		return cached!
@@ -290,7 +290,7 @@ final class PathMatcher: ObservableObject {
 		if matches.isEmpty {
 			return nil
 		}
-		
+
 		var parameterValues: [String : String] = [:]
 
 		if !compiled.parameters.isEmpty {
@@ -309,7 +309,7 @@ final class PathMatcher: ObservableObject {
 				}
 			}
 		}
-		
+
 		// Resolve the glob to get a new relative path.
 		// We only want the part the glob is directly referencing.
 		// I.e., if the glob is `/news/article/*` and the navigation path is `/news/article/1/details`,
@@ -320,7 +320,7 @@ final class PathMatcher: ObservableObject {
 		else {
 			return nil
 		}
-		
+
 		let resolvedGlob = String(path[range])
 		let matchedPath = String(path[relative.endIndex...])
 

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -299,7 +299,13 @@ final class PathMatcher: ObservableObject {
 				if nsrange.location != NSNotFound,
 				   let range = Range(nsrange, in: path)
 				{
-					parameterValues[variable] = String(path[range])
+					var value = String(path[range])
+
+					if value.starts(with: "/") {
+						value = String(value.dropFirst())
+					}
+
+					parameterValues[variable] = value
 				}
 			}
 		}

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -73,6 +73,10 @@ final class SwiftUIRouterTests: XCTestCase {
 			("/news/latest", "/news/latest"),
 			("/user/:id/*", "/user/1"),
 			("/user/:id/*", "/user/1/settings"),
+			("/user/:id?", "/user"),
+			("/user/:id?", "/user/mark"),
+			("/user/:id/:group?", "/user/mark"),
+			("/user/:id/:group?", "/user/mark/admin"),
 		]
 		
 		for (glob, path) in notNil {

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -57,8 +57,6 @@ final class SwiftUIRouterTests: XCTestCase {
 	
 	/// Test if the globs and paths match.
 	func testCorrectMatches() {
-		let pathMatcher = PathMatcher()
-		
 		let notNil: [(String, String)] = [
 			("/", "/"),
 			("/*", "/"),
@@ -80,10 +78,10 @@ final class SwiftUIRouterTests: XCTestCase {
 		]
 		
 		for (glob, path) in notNil {
-			let resolvedGlob = resolvePaths("/", glob)
+			let pathMatcher = PathMatcher()
 			
 			XCTAssertNotNil(
-				try? pathMatcher.match(glob: resolvedGlob, with: path),
+				try? pathMatcher.match(glob: glob, with: path),
 				"Glob \(glob) does not match \(path)."
 			)
 		}
@@ -120,7 +118,7 @@ final class SwiftUIRouterTests: XCTestCase {
 			("/:id?", "/hello", ["id": "hello"]),
 			("/:id", "/hello", ["id": "hello"]),
 			("/:foo/:bar", "/hello/world", ["foo": "hello", "bar": "world"]),
-			("/:foo/:bar?", "/hello/", ["foo": "hello"]),
+			("/:foo/:bar?", "/hello", ["foo": "hello"]),
 			("/user/:id/*", "/user/5", ["id": "5"]),
 		]
 		

--- a/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
+++ b/Tests/SwiftUIRouterTests/SwiftUIRouterTests.swift
@@ -97,7 +97,7 @@ final class SwiftUIRouterTests: XCTestCase {
 		let isNil: [(String, String)] = [
 			("/", "/hello"),
 			("/hello", "/world"),
-			("/foo/:bar?/hello", "/foo/hello"),
+			("/foo/:bar/hello", "/foo/hello"),
 			("/movie", "/movies"),
 			("/movie/*", "/movies"),
 			("/movie/*", "/movies/actor"),


### PR DESCRIPTION
Should fix #40, where a route glob like `/chats/:chatID?` does successfully match with `/chats`.