### PR TITLE
View extension for `SwitchRoutes`

### DIFF
--- a/Sources/SwitchRoutes.swift
+++ b/Sources/SwitchRoutes.swift
@@ -57,3 +57,33 @@ final class SwitchRoutesEnvironment: ObservableObject {
 		isActive = active
 	}
 }
+
+extension View {
+  func switchRoutes<Content: View, T: ViewModifier>(
+    @ViewBuilder content: @escaping () -> Content,
+    modifier: T
+  ) -> some View {
+    GeometryReader { _ in
+      SwitchRoutes {
+        content()
+        Route {
+          self
+        }
+      }
+      .modifier(modifier)
+    }
+  }
+
+  func switchRoutes<Content: View>(
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View {
+    GeometryReader { _ in
+      SwitchRoutes {
+        content()
+        Route {
+          self
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwitchRoutes.swift
+++ b/Sources/SwitchRoutes.swift
@@ -59,7 +59,7 @@ final class SwitchRoutesEnvironment: ObservableObject {
 }
 
 extension View {
-  func switchRoutes<Content: View, T: ViewModifier>(
+  public func switchRoutes<Content: View, T: ViewModifier>(
     @ViewBuilder content: @escaping () -> Content,
     modifier: T
   ) -> some View {
@@ -74,7 +74,7 @@ extension View {
     }
   }
 
-  func switchRoutes<Content: View>(
+  public func switchRoutes<Content: View>(
     @ViewBuilder content: @escaping () -> Content
   ) -> some View {
     GeometryReader { _ in


### PR DESCRIPTION
Whenever I write View code that uses SwitchRoutes, it use a lot of brackets `{ }` , which makes the code hard to read.
For example when writing `MainView`, actual View code placed GeometryReader -> SwitchRoutes -> Route 
```swift
struct MainView: View {
  var body: some View {
    GeometryReader { _ in
      SwitchRoutes {
        Route("child1") {
          ChildView()
        }

        Route("child2") {
          ChildView2()
        }

        Route {
          // main view code here
          VStack {
            Text("MainView")
          }
        }
      }
    }
  }
}
```

so that I added extension functions

```swift
struct MainView: View {
  var body: some View {
    VStack {
      Text("MainView")
    }
    .switchRoutes(
      content: {
        Route("child1") {
          ChildView()
        }

        Route("child2") {
          ChildView2()
        }
      }
    )
  }
}
```


