### PR TITLE
Set Route View `id` as `self.path`

### DIFF
--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -127,6 +127,7 @@ public struct Route<ValidatedData, Content: View>: View {
 			   let routeInformation = routeInformation
 			{
 				content(validatedData)
+          .id(self.path)
 					.environment(\.relativePath, routeInformation.path)
 					.environmentObject(routeInformation)
 					.environmentObject(SwitchRoutesEnvironment())


### PR DESCRIPTION
I'm using SwiftUIRouter library on company Product, and encounter this issue frequently.
https://github.com/frzi/SwiftUIRouter/issues/39

I think that it is better to designate the Rotue's View `id` as `self.path` directly in the library than to individually.



