### PR TITLE
Make current stack index info public

### DIFF
--- a/Sources/Navigator.swift
+++ b/Sources/Navigator.swift
@@ -51,6 +51,10 @@ public final class Navigator: ObservableObject {
 	public var canGoForward: Bool {
 		!forwardStack.isEmpty
 	}
+
+	public var currentStackIndex: Int {
+		historyStack.count - 1
+	}
 	
 	// MARK: Methods.
 	/// Navigate to a new location.


### PR DESCRIPTION
I'm trying to replicate system navigation behaviour: instead of offsetting the view on the whole width, they only offset 0.3 part of width. 

How `NavigationView`+`NavigationLink` animation looks like:

<img src="https://user-images.githubusercontent.com/6103621/162924635-abf4b9ca-f400-4834-b5f9-e0678d8fcd41.gif" width="300"></img>

To replicate it I've created the following transition:
```
let transitionDuration: Double = 2
let screenWidth = UIScreen.main.bounds.width
let hidingScreenWidth = UIScreen.main.bounds.width * 0.3

private func transition(for direction: NavigationAction.Direction?) -> AnyTransition {
	if direction == .deeper || direction == .sideways {
		return AnyTransition.asymmetric(insertion: .offset(x: screenWidth), removal: .offset(x: -hidingScreenWidth))
	} else {
		return AnyTransition.asymmetric(insertion: .offset(x: -hidingScreenWidth), removal: .offset(x: screenWidth))
	}
}
```
The problem is that the disappearing view is always on top - it looks as expected during pop, but not during push:

<img src="https://user-images.githubusercontent.com/6103621/162929016-1942743a-2f33-4b70-acc9-7e8048794cc9.gif" width="300"></img>

The solution is to apply `zIndex` depending on the route index in the back stack - the pushing view must have a higher `zIndex` than the current one.
```
SwitchRoutes {
	Group {
		Route("home") {
			ZStack {
				Color.white
				Button {
					navigator.goBack()
				} label: {
					Text("Back")
				}
			}
		}
		Route("init") {
			ZStack {
				HStack(spacing: 0) {
					Color.gray.frame(width: UIScreen.main.bounds.width * 0.3)
					Color.yellow.frame(maxWidth: .infinity)
				}
				NavLink(to: "/home") {
					Text("Go next")
				}
			}
		}
		Route {
			Navigate(to: "init")
		}
	}.zIndex(Double(navigator.currentStackIndex))
}.navigationTransition()
```

To do this, I need to have information about the current route index, which is what this PR adds.